### PR TITLE
Hotfix/fb share

### DIFF
--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -38,4 +38,10 @@ class Incident extends Model
 
         return $image->storage_filename;
     }
+
+    public function countImages()
+    {
+        return $this->uploads()->where('is_video', 0)->count();
+
+    }
 }

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -13,7 +13,7 @@
     <meta name="description" itemprop="description" content="Many users surf the web with disabled JavaScript or blocked GA universal code, with this solution you&#039;ll be able to log them all.">
     <meta name="keywords" itemprop="keywords" content="Google Analytics,Measurement Protocol,disabled JavaScript,noJS,blocked ga,">
 
-    <meta property="og:url" content="@yield( 'og_url', 'https://savjesno.me' ) ">
+    <meta property="og:url" content="https://savjesno.me">
     <meta property="og:title" content="@yield( 'og_title', 'Prijavi saobraćajne prekršaje na putevima u Crnoj Gori' ) ">
     <meta property="og:description" content="@yield( 'og_description', 'Savjesno.me je građanska inicijativa i nije povezana sa državnim institucijama. Svi podaci pondosioca ostaju zaštićeni i nisu vidljivi. Smatramo da ovakav portal može da popravi saobraćajnu kulturu u Crnoj Gori, ukoliko želiš da daš doprinos javi nam se.' ) ">
     <meta property="og:image" content="@yield( 'og_image', 'https://savjesno.me/assets/img/savjesno-og-img.png' ) ">

--- a/resources/views/layouts/main.blade.php
+++ b/resources/views/layouts/main.blade.php
@@ -13,10 +13,10 @@
     <meta name="description" itemprop="description" content="Many users surf the web with disabled JavaScript or blocked GA universal code, with this solution you&#039;ll be able to log them all.">
     <meta name="keywords" itemprop="keywords" content="Google Analytics,Measurement Protocol,disabled JavaScript,noJS,blocked ga,">
 
-    <meta property="og:url" content="https://savjesno.me">
-    <meta property="og:title" content="Prijavi saobraćajne prekršaje na putevima u Crnoj Gori">
-    <meta property="og:description" content="Savjesno.me je građanska inicijativa i nije povezana sa državnim institucijama. Svi podaci pondosioca ostaju zaštićeni i nisu vidljivi. Smatramo da ovakav portal može da popravi saobraćajnu kulturu u Crnoj Gori, ukoliko želiš da daš doprinos javi nam se.">
-    <meta property="og:image" content="https://savjesno.me/assets/img/savjesno-og-img.png">
+    <meta property="og:url" content="@yield( 'og_url', 'https://savjesno.me' ) ">
+    <meta property="og:title" content="@yield( 'og_title', 'Prijavi saobraćajne prekršaje na putevima u Crnoj Gori' ) ">
+    <meta property="og:description" content="@yield( 'og_description', 'Savjesno.me je građanska inicijativa i nije povezana sa državnim institucijama. Svi podaci pondosioca ostaju zaštićeni i nisu vidljivi. Smatramo da ovakav portal može da popravi saobraćajnu kulturu u Crnoj Gori, ukoliko želiš da daš doprinos javi nam se.' ) ">
+    <meta property="og:image" content="@yield( 'og_image', 'https://savjesno.me/assets/img/savjesno-og-img.png' ) ">
     <meta property="og:site_name" content="Savjesno.me">
     <meta property="og:image:type" content="image/png">
 

--- a/resources/views/pages/incident/show.blade.php
+++ b/resources/views/pages/incident/show.blade.php
@@ -1,5 +1,11 @@
 @extends('layouts.main')
 
+<!--=== OG meta tags ===-->
+@section('og_url', url()->current())
+@section('og_title', $incident->title)
+@section('og_description', $incident->description)
+@section('og_image', ( $incident->countImages() > 0 )  ? '/'.$incident->getFirstImageUrl() : '')
+
 @section('content')
 
     <!--=== Blog Posts ===-->

--- a/resources/views/pages/incident/show.blade.php
+++ b/resources/views/pages/incident/show.blade.php
@@ -1,7 +1,6 @@
 @extends('layouts.main')
 
 <!--=== OG meta tags ===-->
-@section('og_url', url()->current())
 @section('og_title', $incident->title)
 @section('og_description', $incident->description)
 @section('og_image', ( $incident->countImages() > 0 )  ? '/'.$incident->getFirstImageUrl() : '')

--- a/resources/views/pages/incident/show.blade.php
+++ b/resources/views/pages/incident/show.blade.php
@@ -1,8 +1,8 @@
 @extends('layouts.main')
 
 <!--=== OG meta tags ===-->
-@section('og_title', $incident->title)
-@section('og_description', $incident->description)
+@section('og_title', htmlentities($incident->title))
+@section('og_description', htmlentities($incident->description) )
 @section('og_image', ( $incident->countImages() > 0 )  ? '/'.$incident->getFirstImageUrl() : '')
 
 @section('content')


### PR DESCRIPTION
Facebook share incidents - fixed
When sharing incident on facebook, post includes incident photo (if exists), incident title, and description